### PR TITLE
Bugfix for certain windows crashing wayfire on opening.

### DIFF
--- a/src/firedecor-theme.cpp
+++ b/src/firedecor-theme.cpp
@@ -514,7 +514,7 @@ std::string get_from_desktop(std::string path, std::string var) {
 	std::string line;
 	while(std::getline(input_file, line)) {
 		if (auto index = line.find(var); index != std::string::npos) {
-			return (line.substr(index + var.length() + 1));
+			return (line.substr(index + var.length()));
 		}
 	}
 	if (var == "Icon") {


### PR DESCRIPTION
Sorry for sounding rude if I do, but is there a reason this specific line is adding 1 to the end of the substring length?

By removing the +1, this fixes Steam, the Unity Editor and Wayfire Configuration Manager crashing the entire session with a SIGABRT upon their respective windows being spawned.

Tested by modifying the Arch Linux PKGBUILD and recompiling with this change in there. 